### PR TITLE
Relax dependency pinning as is is an installable module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ authors = [
     {name = "Niraj Adhikari", email = "nrjadkry@gmail.com"},
 ]
 dependencies = [
-    "geojson==3.1.0",
-    "shapely==2.0.2",
-    "pyproj>=3.6.1",
+    "geojson>=3.0.0",
+    "shapely==2.0.0",
+    "pyproj>=3.0.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
- The dependency pinning was very strict in `pyproject.toml` using `==`.
- This is good for **applications** that need consistent environments.
- However, this package is an installable module that will be pinned upstream.
- We need more flexible pins, using `>=` the minimum required versions for this to work.

For example, we can't update our dependencies in Drone-TM with the current pins:
![image](https://github.com/user-attachments/assets/7b43383e-be87-4ac8-8150-2fde1f952fb8)

I updated the pins 👍 