### PR TITLE
Add support for generating waylines or waypoints based on generate_each_points flag

### DIFF
--- a/drone_flightplan/waypoints.py
+++ b/drone_flightplan/waypoints.py
@@ -316,30 +316,18 @@ def create_waypoint(
     # Generate GeoJSON features
     features = []
     for index, wp in enumerate(waypoints):
-        if generate_each_points:
-            # For individual waypoints
-            coordinates_4326 = transformer_to_4326(
-                wp["coordinates"].x, wp["coordinates"].y
-            )
-            feature = geojson.Feature(
-                geometry=geojson.Point(coordinates_4326),
-                properties={
-                    "index": index,
-                    "heading": wp["angle"],
-                    "take_photo": wp["take_photo"],
-                    "gimbal_angle": wp["gimbal_angle"],
-                },
-            )
-        else:
-            # For waylines (LineString)
-            coordinates_4326 = [
-                transformer_to_4326(point[0], point[1])
-                for point in wp["coordinates"].coords
-            ]
-            feature = geojson.Feature(
-                geometry=geojson.LineString(coordinates_4326),
-                properties={"index": index},
-            )
+        coordinates_4326 = transformer_to_4326(
+            wp["coordinates"].x, wp["coordinates"].y
+        )
+        feature = geojson.Feature(
+            geometry=geojson.Point(coordinates_4326),
+            properties={
+                "index": index,
+                "heading": wp["angle"],
+                "take_photo": wp["take_photo"],
+                "gimbal_angle": wp["gimbal_angle"],
+            },
+        )
         features.append(feature)
     feature_collection = geojson.FeatureCollection(features)
     return geojson.dumps(feature_collection, indent=2)

--- a/drone_flightplan/waypoints.py
+++ b/drone_flightplan/waypoints.py
@@ -36,13 +36,6 @@ def generate_grid_in_aoi(
             point = Point(x, y)
             if aoi_polygon.contains(point):
                 points.append(point)
-            # Add only unique points that are near the edges of the polygon
-            offset_point = Point(x + x_spacing, y)
-            if (
-                aoi_polygon.contains(offset_point)
-                or aoi_polygon.distance(offset_point) <= x_spacing / 3
-            ):
-                points.append(offset_point)
 
     return points
 

--- a/drone_flightplan/waypoints.py
+++ b/drone_flightplan/waypoints.py
@@ -187,6 +187,23 @@ def exclude_no_fly_zones(points: list[dict], no_fly_zones: list[Polygon]) -> lis
     ]
 
 
+def process_waylines(input_data):
+    processed_data = []
+    count = 0
+
+    for i in range(len(input_data)):
+        if i == 0 or input_data[i]['angle'] == input_data[i - 1]['angle']:
+            count += 1
+        else:
+            count = 1  # Reset count when a new angle is encountered
+
+        # Add only the first two occurrences of each angle
+        if count <= 2:
+            processed_data.append(input_data[i])
+
+    return processed_data
+
+
 def create_waypoint(
     project_area: dict,
     agl: float,
@@ -285,11 +302,8 @@ def create_waypoint(
         for point in path
     ]
 
-    # If generating waylines create a LineString, otherwise keep as waypoints
-    if not generate_each_points:
-        waypoints = [{"coordinates": LineString([p["coordinates"] for p in path])}]
-    else:
-        waypoints = path
+    # If generating waylines, just add two points at each end
+    waypoints = process_waylines(path) if not generate_each_points else path
 
     # If no-fly zones are provided, exclude points that fall inside no-fly zones
     if no_fly_zones:


### PR DESCRIPTION
Release the changes made by @azharcodeit in the PR https://github.com/hotosm/drone-flightplan/pull/14 with some improvements.
- [x] Fix the issue of generating multiple points at the same point. The issue was caused by the offset set at the grid generation function.
- [x] Remove the waypoints that are along the line leaving just the two points at each end when the generate_each_points flag is False 