### PR TITLE
Terrain following waylines

### DIFF
--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -8,6 +8,7 @@ import argparse
 import json
 from shapely.geometry import shape
 from shapely import distance
+from shapely.ops import transform
 from pyproj import Transformer
 
 
@@ -38,20 +39,23 @@ def extractLines(plan):
 
 def trim(line, threshold):
     """
-    Accepts a waypoint flight line as a list of dicts
+    Accepts a waypoint flight line as a list of dicts from GeoJSON
     Returns a wayline flight line, with the first and last point intact
     but as many as possible of the intermediate points removed
     consistent with not exceeding the threshold of deviation from AGL
     as a list of dicts
     """
-    transformer = Transformer.from_crs(4326, 3857)
+    transformer = Transformer.from_crs(4326, 3857, always_xy=True).transform
     firstpoint = shape(line[0]['geometry'])
     lastpoint = shape(line[-1]['geometry'])
+    fp = transform(transformer, firstpoint)
+    lp = transform(transformer, lastpoint)
     print(f"A line with first point {firstpoint} and last point {lastpoint}"
-          f"for a total distance of {distance(firstpoint, lastpoint)}")
+          f"for a total distance of {distance(fp, lp)}")
     for point in line:
-        pointshape = shape(point['geometry'])
-        #print(pointshape)
+        ps = shape(point['geometry'])
+        pm = transform(transformer, ps)
+        #print(f'{ps}, {pm}')
 
 
 if __name__ == "__main__":
@@ -85,5 +89,6 @@ if __name__ == "__main__":
     for line in lines:
         wayline = trim(line, a.threshold)
         waylines.append(wayline)
+    print(waylines)
 
 

--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -2,6 +2,9 @@
 """
 Convert a terrain following drone waypoint mission to a terrain following wayline mission by removing as many waypoints as can be done without deviating beyond a certain threshold from the desired Altitude Above Ground Level.
 """
+import logging
+
+log = logging.getLogger(__name__)
 
 import sys, os
 import argparse
@@ -158,8 +161,8 @@ def inject(kp, tp, threshold):
         injection_point = None
         points_to_traverse = segment[1]['index'] - segment[0]['index']
 
-        pointsinfo = []
-        pointsinfo.append([segment[0]['index'],fp,fp.z,fp.z,0,0,'first'])
+        #pointsinfo = []
+        #pointsinfo.append([segment[0]['index'],fp,fp.z,fp.z,0,0,'first'])
 
         for i in range(1, points_to_traverse):
             pt = tp[i]['geometry']
@@ -172,14 +175,14 @@ def inject(kp, tp, threshold):
                 max_agl_difference = agl_difference
                 max_agl_difference_point = tp[i]['index']
                 injection_point = i
-            pointsinfo.append([tp[i]['index'], tp[i]['geometry'],expected_z,
-                               z, ptrun, agl_difference])
-        pointsinfo.append([segment[1]['index'],lp,lp.z,lp.z,rise,run,'last'])
+            #pointsinfo.append([tp[i]['index'], tp[i]['geometry'],expected_z,
+            #                   z, ptrun, agl_difference])
+        #pointsinfo.append([segment[1]['index'],lp,lp.z,lp.z,rise,run,'last'])
         if injection_point:
             new_segment = [segment[0], tp[injection_point], segment[1]]
             for new_point in new_segment:
                 new_keeperpoints.append(new_point['index'])
-            pointsinfo[injection_point].append('injection point')
+            #pointsinfo[injection_point].append('injection point')
         else:
             for point in segment:
                 new_keeperpoints.append(point['index'])
@@ -218,10 +221,8 @@ def waypoints2waylines(injson, threshold):
     # the case that all flight plans will have a dummy first point
     lines = extract_lines(inplan[1:])
 
-    print(f"\nThis flight plan consists of {len(lines)} lines "
+    log.info(f"\nThis flight plan consists of {len(lines)} lines "
           f"and {len(inplan)} waypoints.")
-    #for line in lines:
-    #    print(f'A line {len(line)} points long')
     
     features = []
     features.append(inplan[0])
@@ -235,7 +236,7 @@ def waypoints2waylines(injson, threshold):
     outgeojson['type'] = injson['type']
     outgeojson['features'] = features
 
-    print(f"\nThe output flight plan consists of {len(features)} waypoints.")
+    log.info(f"The output flight plan consists of {len(features)} waypoints.")
 
     return outgeojson
 
@@ -272,7 +273,17 @@ if __name__ == "__main__":
 
     a = p.parse_args()
 
-    print(f"\nLet's fuckin' goooo!")
+    verbose = True # set via argparse
+
+    logging.basicConfig(
+        level="DEBUG" if verbose else "INFO",
+        format=("%(asctime)s.%(msecs)03d [%(levelname)s] "
+                "%(name)s | %(funcName)s:%(lineno)d | %(message)s"),
+        datefmt="%y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
+        )
+
+    log.info(f"Let's fuckin' goooo!")
 
     injson = json.load(open(a.infile))
 

--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3
+"""
+Convert a terrain following drone waypoint mission to a terrain following wayline mission by removing as many waypoints as can be done without deviating beyond a certain threshold from the desired Altitude Above Ground Level.
+"""
+
+import argparse
+
+import json
+from shapely.geometry import shape
+from shapely import distance
+from pyproj import Transformer
+
+
+
+def extractLines(plan):
+    """
+    Accepts a flight plan as a list of dicts
+    Returns each of the individual lines of a flight plan as list of dicts
+    """
+    # Empty list to contain all of the lines in the flight plan, each line
+    # defined as a series of points proceeding along the same heading
+    lines = []
+    # Empty list to hold the points of each individual line
+    currentline = []
+    lastheading = None
+
+    for point in plan:
+        currentheading = point['properties']['heading']
+        # If it's not the first line, and the direction has changed
+        if lastheading and currentheading != lastheading:
+         # Yep, changed direction. Add the current line to the list of lines
+            # and empty the current line before adding the current point.
+            lines.append(currentline)
+            currentline = []
+        currentline.append(point)
+        lastheading = currentheading
+    return lines
+
+def trim(line, threshold):
+    """
+    Accepts a waypoint flight line as a list of dicts
+    Returns a wayline flight line, with the first and last point intact
+    but as many as possible of the intermediate points removed
+    consistent with not exceeding the threshold of deviation from AGL
+    as a list of dicts
+    """
+    transformer = Transformer.from_crs(4326, 3857)
+    firstpoint = shape(line[0]['geometry'])
+    lastpoint = shape(line[-1]['geometry'])
+    print(f"A line with first point {firstpoint} and last point {lastpoint}"
+          f"for a total distance of {distance(firstpoint, lastpoint)}")
+    for point in line:
+        pointshape = shape(point['geometry'])
+        #print(pointshape)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+
+    p.add_argument("infile", help="input flight plan as GeoJSON")
+    p.add_argument("-th", "--threshold",
+                   help='Allowable altitude deviation in meters', default=2)
+    #p.add_argument("outfile", help="output file")
+
+    a = p.parse_args()
+
+    print(f"\nLet's fuckin' goooo!")
+
+    inplan = json.load(open(a.infile))['features']
+
+    lines = extractLines(inplan)
+
+    print(f"\nThis flight plan consists of {len(lines)} lines, like so:")
+    for line in lines:
+        print(f'A line {len(line)} points long')
+
+    #print(f'\nFor reference, the second line looks like this:')
+    #for point in lines[1]:
+    #    print(f"A point with Heading: {point['properties']['heading']}, "
+    #          f"Altitude: {point['properties']['altitude']}, "
+    #          f"take photo: {point['properties']['take_photo']}")
+
+    print(f"\nOk, let's examine the altitude profiles of the flight lines:")
+    waylines = []
+    for line in lines:
+        wayline = trim(line, a.threshold)
+        waylines.append(wayline)
+
+

--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -4,53 +4,75 @@ Convert a terrain following drone waypoint mission to a terrain following waylin
 """
 
 import argparse
-
 import json
 from shapely.geometry import shape
 from shapely import distance
 from shapely.ops import transform
 from pyproj import Transformer
 
-
-
-
 def extract_lines(plan):
     """
-    Accepts a flight plan as a list of dicts
-    Returns each of the individual lines of a flight plan as list of dicts
+    Return the waypoints of a flight plan as individual unidirectional lines.
+    Works by inspecting the heading property of each point and creating
+    a new line each time the direction changes.
+
+    Parameter
+    --------
+    plan : list
+        The 'features' portion of a GeoJSON flight plan from the Drone Tasking
+        Manager. This consists of a list of waypoints (which are dicts)
+
+    Returns
+    --------
+    waylines : list
+        A list of lists containing waypoints (which are dicts)
+    
     """
     # Empty list to contain all of the lines in the flight plan, each line
     # defined as a series of points proceeding along the same heading
-    lines = []
-    # Empty list to hold the points of each individual line
+    waylines = []
+    
+    # Empty list to hold the points of an individual unidirectional line
     currentline = []
     lastheading = None
 
     for point in plan:
-        #print(point)
         currentheading = point['properties']['heading']
         # If it's not the first line, and the direction has changed
         if lastheading and currentheading != lastheading:
             # Yep, changed direction. Add the current line to the list of lines
-            # and empty the current line before adding the current point.
-            lines.append(currentline)
+            # and flush the current line before adding the current point.
+            waylines.append(currentline)
             currentline = []
         currentline.append(point)
         lastheading = currentheading
-    return lines
+    return waylines
 
 def trim(line, threshold):
     """
-    Accepts a waypoint flight line as a list of dicts from GeoJSON
-    Returns a wayline flight line, with the first and last point intact
+    Return a wayline flight line, with the first and last point intact
     but as many as possible of the intermediate points removed
-    consistent with not exceeding the threshold of deviation from AGL
-    as a list of dicts
+    consistent with not exceeding the threshold of deviation from AGL.
+
+    Parameters
+    --------
+    line : list
+        A waypoint flight line as a list of waypoints (dicts)
+
+    threshold : float
+        The allowable deviation from a consistent AGL in m
+
+    Returns
+    --------
+    new_line : list
+        A wayline as list of waypoints (dicts), hopefully indistinguishable
+        from the input line, but with fewer points while retaining the
+        AGL within the threshold
     """
-    print(f"\n\n************************************\nHere's another line:")
+    # Work in meters. Assumes input is in EPSG:4326 (will break if not).
     transformer = Transformer.from_crs(4326, 3857, always_xy=True).transform
     
-    # All points, indexed, in EPSG:3857 (tp for transformed_points)
+    # Create a set of all points, indexed, in EPSG:3857 (tp=transformed_points)
     tp = []
     for point in line:
         indexedpoint = {}
@@ -62,12 +84,25 @@ def trim(line, threshold):
     # Keeper points (indexes only)we know about (initially first and last)
     kp = [tp[0]['index'], tp[-1]['index']]
 
-    # new keeper segments after injection
+    # New keeper points after injection of the intermediate points needed
+    # to maintain consistent AGL
+    # nkp = new keeper points
     nkp = inject(kp, tp, threshold)
 
+    # Keep injecting needed points until there aren't any more needed
+    # (presumably because the AGL differences are below the threshold)
+    #
+    # NOTE: Probably quite inefficient; it may be doing the injection twice,
+    # once to check if it changes anything, and then again to actually do it.
+    # However, it's working fast for now (and flight plans aren't likely to
+    # become all that huge, so whatever, leave it pending profiling.
     while set(inject(nkp, tp, threshold)) != set(nkp):
         nkp = inject(nkp, tp, threshold)
 
+    # The way we're handling segments in the inject function means that there
+    # are duplicate points in the keeperpoints. Make it a set, which anyway
+    # is more efficient and safer to use as a filter.
+    # nkpset = new keeper point set
     nkpset = set(nkp)
     new_line = [p for p in line if p['properties']['index'] in nkpset]
     return new_line
@@ -75,35 +110,51 @@ def trim(line, threshold):
 def inject(kp, tp, threshold):
     """
     Add the point furthest from consistent AGL (if over threshold)
-    All points must be in a single line (as from function extract_lines
-    kp is the keeper_points (the ones we already know we need)
-    tp is the transformed points (in EPSG:3857)
-    threshold is how far the point should be allowed to deviate from AGL
 
-    Returns a new list of keeperpoints
+    Parameters:
+    --------
+    kp : list
+        A list of integer waypoint indexes, the "keeper points' we already know
+        must be retained (such as the start and end points of the waylines)
+    tp : list
+        A list of actual waypoints (dicts from GeoJSON)
+
+    threshold : float
+        The allowable deviation from a consistent AGL in m
+
+    Returns:
+    --------
+    new_keeperpoints : list
+        A list of integer waypoint indexes
     """
-    print(f"\nRunning injection.\nkeeper points in this line: {kp}\n")
+    # Create segements between existing keeper waypoints; each segement
+    # will be examined to see if another one in the middle is needed
     currentpoint = kp[0]
     segments = []
     for endpoint in kp[1:]:
-        print(f"Going for currentpoint {currentpoint} and endpoint {endpoint}")
         segment = (tp[currentpoint - kp[0]], tp[endpoint - kp[0]])
         segments.append(segment)
         currentpoint = endpoint
 
     new_keeperpoints = []
 
+    # Run through all the segments between keeperpoints and inject (from
+    # the entire list of original waypoints) those needed to keep AGL
+    # deviation below the threshold
     for segment in segments:
         fp = segment[0]['geometry']
         run = distance(fp, segment[1]['geometry'])
         rise = segment[1]['geometry'].z - segment[0]['geometry'].z
-        slope = rise / run
-        print(f"\nRun: {run}, Rise: {rise}, Slope: {slope}\n")
+        #print(f"rise: {rise}, run: {run}")
+        # Avoid divide by zero if for some reason two waypoints are on
+        # top of one another
+        slope = 0
+        if run:
+            slope = rise / run
         max_agl_difference = 0
         max_agl_difference_point = 0
         injection_point = None
         points_to_traverse = segment[1]['index'] - segment[0]['index']
-        #print("index, expected z, z, AGL Difference")
         for i in range(1, points_to_traverse):
             pt = tp[i]['geometry']
             z = pt.z
@@ -115,9 +166,8 @@ def inject(kp, tp, threshold):
                 max_agl_difference = agl_difference
                 max_agl_difference_point = tp[i]['index']
                 injection_point = i
-            #print(f"{tp[i]['index']}: {expected_z}, {z}, {agl_difference}")
-        print(f"Max AGL difference in this segment: {max_agl_difference}"
-              f" at point {max_agl_difference_point}")
+        #print(f"Max AGL difference in this segment: {max_agl_difference}"
+        #      f" at point {max_agl_difference_point}")
         if injection_point:
             new_segment = [segment[0], tp[injection_point], segment[1]]
             for new_point in new_segment:
@@ -129,13 +179,32 @@ def inject(kp, tp, threshold):
     return new_keeperpoints
             
 if __name__ == "__main__":
+    """
+    Remove as many as possible of the waypoints in a Drone Tasking Manager
+    flight plan, leaving those waypoints needed to prevent the AGL from
+    exceeding a specified threshold.
+
+    Parameters:
+    --------
+    infile : path
+        An input GeoJSON file from the Drone Tasking Manager
+    outfile : path
+        An output GeoJSON file, hopefully identical to the input file but with
+        many fewer waypoints but still maintaining AGL within threshold
+    threshold : float
+        The allowable deviation from consistent AGL.
+
+    Returns:
+    --------
+    Writes a GeoJSON file containing the waypoints remaining after removal
+    of as many as we can without AGL deviation exceeding threshold
+    """
     p = argparse.ArgumentParser()
 
     p.add_argument("infile", help="input flight plan as GeoJSON")
     p.add_argument("outfile", help="output flight plan as GeoJSON")
     p.add_argument("-th", "--threshold", type=float,
                    help='Allowable altitude deviation in meters', default=5)
-    #p.add_argument("outfile", help="output file")
 
     a = p.parse_args()
 
@@ -146,12 +215,16 @@ if __name__ == "__main__":
     inheader = injson['type']
     inplan = injson['features']
 
-    # Skip the first point which is a dummy waypoint in mid flighplan
+    # Skip the first point which is a dummy waypoint in the middle of
+    # the flightplan area (for safety ascending to working altitude)
+    # TODO: this should probably be a parameter as it's not necessarily
+    # the case that all flight plans will have a dummy first point
     lines = extract_lines(inplan[1:])
 
-    print(f"\nThis flight plan consists of {len(lines)} lines, like so:")
-    for line in lines:
-        print(f'A line {len(line)} points long')
+    print(f"\nThis flight plan consists of {len(lines)} lines "
+          f"and {len(inplan)} waypoints.")
+    #for line in lines:
+    #    print(f'A line {len(line)} points long')
     
     features = []
     for line in lines:
@@ -163,6 +236,8 @@ if __name__ == "__main__":
 
     outgeojson['type'] = injson['type']
     outgeojson['features'] = features
+
+    print(f"\nThe output flight plan consists of {len(features)} waypoints.")
         
     with open(a.outfile, 'w') as output_file:
         json.dump(outgeojson, output_file)


### PR DESCRIPTION
# Overview
I've completed a prototype of a module that takes a waypoint flight with terrain following and converts it to a wayline flight by removing as many waypoints as possible, leaving those required to maintain a consistent Altitude Above Ground Level (AGL).

# Rationale
The DroneTM is currently targeting only DJI drones that support waypoint flights—in particular the DJI Mini 4 Pro _(nota bene: we absolutely intend to support other drones, including non-DJI drones, after getting the Minimum Viable Product working, and we especially plan to support open-source drones as a high priority)_—so we're constrained by the limitations of DJI hardware.

In particular the [RC 2 controller](https://www.dji.com/global/rc-2) that DJI provides with most of their recent small drones has a built-in Android device in it; this device is running the DJI Go application that interfaces with the drone. The embedded Android device in the RC 2 appears to be remarkably feeble, and—apparently together with the poor design of the DJI Go application—it's not able to display more than a hundred-and-some-odd waypoints without crashing. This causes exciting flights, during which the controller freezes or even crashes completely and reboots! 

Fortunately the drones seem to usually complete their assigned flight plan mission (the desired behavior) or abort and return to home (less good but better than some of the alternatives), but obviously we don't want controllers freezing or crashing while drones are in flight (the [RCN2](https://store.dji.com/product/dji-mini-4-pro?vid=148581&from=search-result-v2&position=6&total_result=20&_gl=1%2Amzzhmh%2A_up%2AMQ..&gclid=CjwKCAjwx4O4BhAnEiwA42SbVMK5PgQPbZ0SC8aDZvIJlCsq9y6ZFI6Af7tvo1C2LHkSKnZc_aJ4kBoCXPMQAvD_BwE), an alternative controller that works with these drones, functions by tethering to an external Android or iOS device, and most decent external devices can handle more waypoints than the embedded device in the RC2). 

Either way, we often need to reduce the number of waypoints needed to execute a mission. For missions without terrain following, this is easy; we just create _waylines_ instead of waypoints, set the drone to capture photos every 2 seconds, and send it along. But to follow the elevation changes of the terrain, we can't just set a start and end point. So we need some, but not all, of the waypoints to ensure that the terrain following doesn't get too far off, but not more than needed because the controller can't handle too many points. 

This pull request introduces a module that removes many of the waypoints (the majority of them, in most cases) in a full grid, leaving enough that when executed as a wayline mission the Altitude Above Ground Level (AGL) shouldn't get further than a specified threshold. 

# What the terrain following waypoints module does
It accepts the GeoJSON flight plan from the current DroneTM (as downloaded from the production server) and returns another GeoJSON that is almost identical but contains only the necessary waypoints to maintain AGL.

# Example input/output
## Here's how that basically looks:

![Terrain_following_flight_plan_view](https://github.com/user-attachments/assets/91c1e34a-ad8c-4a9a-8e64-d7e6415ba345)

![Terrain_following_flight_plan_view_trimmed](https://github.com/user-attachments/assets/75e30d28-486c-44d7-9301-1c5038ee2916)

The waypoint flight plan of 901 points (essentially impossible for the DJI RC 2 controller to handle) gets cut down to 156 (probably ok). 

## How does it look in 3D? 

Glad you asked. Like this:

![01_Terrain_following_Flight_plan_Tokeh_15](https://github.com/user-attachments/assets/6f1db8d5-7c81-4ed9-af90-9ceef1bc196f)

![02_Terrain_following_Flight_plan_Tokeh_15_with_Paths](https://github.com/user-attachments/assets/c9712457-7885-4cdb-b3f8-fb7e2902208e)






