### PR TITLE
When removing waypoints for terrain following with waylines, resequence index numbers

### DIFF
--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -231,10 +231,17 @@ def waypoints2waylines(injson, threshold):
         for point in wayline:
             features.append(point)
 
+    sequential_features = []
+    indexcount = 0
+    for feature in features:
+        feature['properties']['index'] = indexcount
+        indexcount = indexcount + 1
+        sequential_features.append(feature)
     outgeojson = {}
 
     outgeojson['type'] = injson['type']
-    outgeojson['features'] = features
+    outgeojson['features'] = sequential_features
+    
 
     log.info(f"The output flight plan consists of {len(features)} waypoints.")
 

--- a/drone_flightplan/terrain_following_waylines.py
+++ b/drone_flightplan/terrain_following_waylines.py
@@ -232,10 +232,8 @@ def waypoints2waylines(injson, threshold):
             features.append(point)
 
     sequential_features = []
-    indexcount = 0
-    for feature in features:
-        feature['properties']['index'] = indexcount
-        indexcount = indexcount + 1
+    for idx, feature in enumerate(features):
+        feature['properties']['index'] = idx
         sequential_features.append(feature)
     outgeojson = {}
 


### PR DESCRIPTION
# WPML index numbers need to be sequential

When we create large terrain following flight plans, we then trim them to remove waypoints that are not needed to maintain Altitude Above Ground Level (AGL) within a specific threshold. However, when removing waypoints, the remaining waypoints no longer have sequential, incremented-by-one index numbers. The DJI controller crashes when these wayline flights are loaded. 

I've modified the `terrain_following_waylines` module to run through the final set of remaining waypoints after trimming and rename the indexes sequentially.

Now the trimmed wayline files load onto the controller and don't crash. However, they are _fucking wiggly_ again, so I'll either have to add the extra straightening waypoints again (as @nrjadkry requested) or figure out another setting in the WPML to stop the stupid spline interpolation that the drone is using to create a smooth cinematic experience.